### PR TITLE
fix: use a slice directly in the extended_commitment_factory

### DIFF
--- a/src/ristretto/pedersen/extended_commitment_factory.rs
+++ b/src/ristretto/pedersen/extended_commitment_factory.rs
@@ -21,7 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use bulletproofs_plus::{generators::pedersen_gens::ExtensionDegree, PedersenGens};
-use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::Identity};
+use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
 
 use crate::{
     commitment::{ExtendedHomomorphicCommitmentFactory, HomomorphicCommitment},
@@ -92,10 +92,7 @@ impl ExtendedHomomorphicCommitmentFactory for ExtendedPedersenCommitmentFactory 
         k_vec: &[RistrettoSecretKey],
         v: &RistrettoSecretKey,
     ) -> Result<PedersenCommitment, RangeProofError> {
-        let k_vec: Vec<Scalar> = k_vec.to_vec().iter().map(|k| k.0).collect();
-        let c = self
-            .0
-            .commit(v.0, &k_vec)
+        let c = self.0.commit(v, k_vec)
             .map_err(|e| RangeProofError::ExtensionDegree(e.to_string()))?;
         Ok(HomomorphicCommitment(RistrettoPublicKey::new_from_pk(c)))
     }

--- a/src/ristretto/ristretto_keys.rs
+++ b/src/ristretto/ristretto_keys.rs
@@ -22,6 +22,7 @@
 
 //! The Tari-compatible implementation of Ristretto based on the curve25519-dalek implementation
 use std::{
+    borrow::Borrow,
     cmp::Ordering,
     fmt,
     fmt::Debug,
@@ -175,6 +176,14 @@ impl From<u64> for RistrettoSecretKey {
     fn from(v: u64) -> Self {
         let s = Scalar::from(v);
         RistrettoSecretKey(s)
+    }
+}
+
+//---------------------------------------------      Borrow impl     -------------------------------------------------//
+
+impl<'a> Borrow<Scalar> for &'a RistrettoSecretKey {
+    fn borrow(&self) -> &Scalar {
+        &self.0
     }
 }
 


### PR DESCRIPTION
The patch based on https://github.com/tari-project/bulletproofs-plus/pull/12 to eliminate values copying.